### PR TITLE
Fix build with GCC 4.7

### DIFF
--- a/single_inst/qtlocalpeer.cpp
+++ b/single_inst/qtlocalpeer.cpp
@@ -50,6 +50,7 @@ static PProcessIdToSessionId pProcessIdToSessionId = 0;
 #endif
 #if defined(Q_OS_UNIX)
 #include <time.h>
+#include <unistd.h>
 #endif
 
 namespace QtLP_Private {


### PR DESCRIPTION
Simply adds a missing include that breaks build with GCC 4.7
